### PR TITLE
Prevent adding shutter PPA repo multiple times

### DIFF
--- a/tasks/xenial-base.yml
+++ b/tasks/xenial-base.yml
@@ -5,4 +5,6 @@
     state: present
 
 - name: Add shutter xenial PPA repository
-  shell: echo 'deb http://ppa.launchpad.net/shutter/ppa/ubuntu xenial main' >> /etc/apt/sources.list && echo 'deb-src http://ppa.launchpad.net/shutter/ppa/ubuntu xenial main' >> /etc/apt/sources.list
+  apt_repository:
+    repo: deb http://ppa.launchpad.net/shutter/ppa/ubuntu xenial main
+    state: present


### PR DESCRIPTION
The repo was added multiple times, resulting in a lot of warnings
in apt. Use the standard ansible way of adding a repo